### PR TITLE
Improve .gitignore to exclude Python cache and outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,31 @@
 *.DS_Store
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+
+# Checkpoints and model weights
+checkpoints/
+work_dirs/
+*.pth
+*.ckpt
+
+# Outputs
+outputs/
+results/
+demo_output/
+
+# Logs
+*.log
+wandb/
+
+# IDE
+.vscode/
+.idea/
+
+# Temporary files
+*.swp
+*.swo
+*~


### PR DESCRIPTION
- Add __pycache__/ and *.pyc exclusions
- Add checkpoints/ and model weights (*.pth)
- Add outputs/, results/, work_dirs/
- Add logs and wandb/
- Add IDE configs (.vscode/, .idea/)

This keeps the repository clean and prevents accidentally committing large files or temporary build artifacts.